### PR TITLE
fixed order of routes, and login should now redirects to the create page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -18,8 +18,8 @@ export default new Router({
   base: process.env.BASE_URL,
   routes: [
     { path: '/cats', name: 'cats-index', component: CatsIndex },
-    { path: '/cats/:id', name: 'cats-show', component: CatsShow },
     { path: '/cats/new', name: 'cats-new', component: CatsNew },
+    { path: '/cats/:id', name: 'cats-show', component: CatsShow },
     { path: '/cats/:id/edit', name: 'cats-edit', component: CatsEdit },
     { path: '/cats/:id/catnections', name: 'cats-connections', component: CatsConnections},
     { path: '/', name: 'sign-up', component: SignUp },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -56,7 +56,7 @@ export default {
           axios.defaults.headers.common["Authorization"] =
             "Bearer " + response.data.jwt;
           localStorage.setItem("jwt", response.data.jwt);
-          this.$router.push("'/cats/'" + this.cat.id);
+          this.$router.push("/cats/new");
         })
         .catch(error => {
           this.errors = ["Invalid email or password."];

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="logout">
+    <div class="container">
+      <router-link to="/logout">Logout</router-link>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
I think I fixed the login. Create a new user and try it out. 

Right now, the login page will always redirect to the create a new cat page. I'm hoping that I can figure out a way to use a conditional statement to only direct the user to the new page if they haven't already created a profile.